### PR TITLE
Fix paths and directory permissions

### DIFF
--- a/providers/private.rb
+++ b/providers/private.rb
@@ -42,7 +42,7 @@ action :create do
   directory ::File.dirname(key_file) do
     owner new_resource.user
     group new_resource.group
-    mode 0600
+    mode 0700
     only_if { new_resource.manage_key_dir }
   end
 

--- a/providers/private.rb
+++ b/providers/private.rb
@@ -47,6 +47,7 @@ action :create do
   end
 
   file "ssh_private_key_file_#{key_file}" do
+    path key_file
     content key_content
     owner new_resource.user
     group new_resource.group
@@ -54,6 +55,7 @@ action :create do
   end
 
   template "ssh_wrapper_file_#{wrapper_file}" do
+    path wrapper_file
     cookbook new_resource.cookbook
     source new_resource.template
     owner new_resource.user


### PR DESCRIPTION
The name of the key and the wrapper was changed to use a prefix but the path was not set, it default is the name thus it failed.
Changed the permission of the folder containing the key to 0700 to include execution.
