### PR TITLE
key_file attribute

### DIFF
--- a/resources/private.rb
+++ b/resources/private.rb
@@ -24,7 +24,7 @@ default_action :create
 attribute :enable_wrapper,  :kind_of => [TrueClass, FalseClass], :default => node['ssh_key_wrapper']['enable_wrapper']
 attribute :wrapper_file,    :kind_of => String, :default => nil
 attribute :manage_key_dir,  :kind_of => [TrueClass, FalseClass], :default => node['ssh_key_wrapper']['manage_key_dir']
-attribute :key_file,        :kind_of => String, :required => true, :default => nil
+attribute :key_file,        :kind_of => String, :default => nil
 attribute :key_secret,      :kind_of => String, :default => nil
 attribute :key_name,        :kind_of => String, :name_attribute => true,  :default => nil
 attribute :databag,         :kind_of => String, :default => node['ssh_key_wrapper']['databag']


### PR DESCRIPTION
Dear Virender,

sending a pull request which fixes the error raised when the key_file is not defined in recipe call.